### PR TITLE
Prevent long delays clearing console

### DIFF
--- a/XcodeColors/Info.plist
+++ b/XcodeColors/Info.plist
@@ -16,8 +16,9 @@
 	<array>
 		<string>63FC1C47-140D-42B0-BB4D-A10B2D225574</string>
 		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
-		<string>640F884E-CE55-4B40-87C0-8869546CAB7A</string>
 		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
+		<string>AD68E85B-441B-4301-B564-A45E4919A6AD</string>
+		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
 	</array>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>

--- a/XcodeColors/XcodeColors.m
+++ b/XcodeColors/XcodeColors.m
@@ -271,6 +271,8 @@ void ApplyANSIColors(NSTextStorage *textStorage, NSRange textStorageRange, NSStr
 		{
 			NSRange seqRange = [seqRangeValue rangeValue];
 			[textStorage addAttributes:clearAttrs range:seqRange];
+			seqRange.length = 2;
+			[textStorage replaceCharactersInRange:seqRange withString:@"\\["];
 		}
 	}
 }


### PR DESCRIPTION
This change avoids very long delays as the escape sequences are reprocessed when you ask to clear a console containing a large amount (mb) of output. To replicate download https://github.com/johnno1962/Xtrace, enable coloring on line 150 of XRAppDelegate.m run the application and then clear the console. There is often a very long delay this fix replaces the escape sequence avoiding their being processed twice.
