### PR TITLE
Add support for Xcode 6

### DIFF
--- a/XcodeColors/Info.plist
+++ b/XcodeColors/Info.plist
@@ -18,6 +18,7 @@
 		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
 		<string>640F884E-CE55-4B40-87C0-8869546CAB7A</string>
 		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
+		<string>AD68E85B-441B-4301-B564-A45E4919A6AD</string>
 	</array>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>


### PR DESCRIPTION
Xcode 6b1 & 6b2 have the same UUID
