### PR TITLE
Add DVTPlugInCompatibilityUUIDs for Xcode 6.4 betas 1, 2.

### DIFF
--- a/XcodeColors/Info.plist
+++ b/XcodeColors/Info.plist
@@ -24,6 +24,8 @@
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
 		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
+		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
+		<string>8DC44374-2B35-4C57-A6FE-2AD66A36AAD9</string>
 	</array>
 	<key>LSApplicationCategoryType</key>
 	<string></string>


### PR DESCRIPTION
This includes the new `DVTPlugInCompatibilityUUID` value from the following command: 

```
$ defaults read /Applications/Xcode-beta.app/Contents/Info DVTPlugInCompatibilityUUID
```

The first value is from beta 1, the second from beta 2.