### PR TITLE
Support Xcode 7 (Beta 1)

### DIFF
--- a/XcodeColors/Info.plist
+++ b/XcodeColors/Info.plist
@@ -27,6 +27,7 @@
 		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
 		<string>8DC44374-2B35-4C57-A6FE-2AD66A36AAD9</string>
 		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
+		<string>AABB7188-E14E-4433-AD3B-5CD791EAD9A3</string>
 	</array>
 	<key>LSApplicationCategoryType</key>
 	<string></string>


### PR DESCRIPTION
Added "AABB7188-E14E-4433-AD3B-5CD791EAD9A3" to DVTPlugInCompatibilityUUIDs in order to support Xcode 7 (Beta 1)