### PR TITLE
Add Xcode 6.4b4, 6.4 GM compat UUID.

### DIFF
--- a/XcodeColors/Info.plist
+++ b/XcodeColors/Info.plist
@@ -29,6 +29,7 @@
 		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
 		<string>AABB7188-E14E-4433-AD3B-5CD791EAD9A3</string>
 		<string>5EDAC44F-8E0B-42C9-9BEF-E9C12EEC4949</string>
+		<string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
 	</array>
 	<key>LSApplicationCategoryType</key>
 	<string></string>

--- a/XcodeColors/Info.plist
+++ b/XcodeColors/Info.plist
@@ -28,6 +28,7 @@
 		<string>8DC44374-2B35-4C57-A6FE-2AD66A36AAD9</string>
 		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
 		<string>AABB7188-E14E-4433-AD3B-5CD791EAD9A3</string>
+		<string>5EDAC44F-8E0B-42C9-9BEF-E9C12EEC4949</string>
 	</array>
 	<key>LSApplicationCategoryType</key>
 	<string></string>


### PR DESCRIPTION
The UUID ending in `949` is the UUID for Xcode 6.4 Beta 4.

The UUID ending in `A90` is the UUID for Xcode 6.4 GM.