### PR TITLE
Update for Xcode 6.4

### DIFF
--- a/XcodeColors.xcodeproj/project.pbxproj
+++ b/XcodeColors.xcodeproj/project.pbxproj
@@ -259,7 +259,7 @@
 		089C1669FE841209C02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastUpgradeCheck = 0640;
 			};
 			buildConfigurationList = 1DEB913E08733D840010E9CD /* Build configuration list for PBXProject "XcodeColors" */;
 			compatibilityVersion = "Xcode 3.2";


### PR DESCRIPTION
Xcode 6.4 shows a warning requesting to upgrade project settings. This patch does it.